### PR TITLE
Add JwtHeaderExtractor and update PayoutServiceImpl for modular certi…

### DIFF
--- a/obs/obs-rest/src/main/java/com/adorsys/webank/obs/resource/PayoutRest.java
+++ b/obs/obs-rest/src/main/java/com/adorsys/webank/obs/resource/PayoutRest.java
@@ -30,7 +30,6 @@ public class PayoutRest implements PayoutRestApi {
         }
         try {
             String jwtToken = extractJwtFromHeader(authorizationHeader);
-            log.info("JWT Token: " + jwtToken);
             JwtValidator.validateAndExtract(jwtToken, request.getRecipientAccountId(), request.getAmount(), request.getSenderAccountId());
             String result = payoutService.payout(request, jwtToken) ;
             return ResponseEntity.status(HttpStatus.CREATED).body(result);

--- a/obs/obs-service-api/src/main/java/com/adorsys/webank/obs/service/RecoveryServiceApi.java
+++ b/obs/obs-service-api/src/main/java/com/adorsys/webank/obs/service/RecoveryServiceApi.java
@@ -1,7 +1,6 @@
 package com.adorsys.webank.obs.service;
 
-import com.adorsys.webank.obs.dto.RecoveryDto;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.*;
 
 @Service
 public interface RecoveryServiceApi {

--- a/obs/obs-service-impl/src/main/java/com/adorsys/webank/obs/security/JwtCertValidator.java
+++ b/obs/obs-service-impl/src/main/java/com/adorsys/webank/obs/security/JwtCertValidator.java
@@ -4,13 +4,11 @@ import com.nimbusds.jose.*;
 import com.nimbusds.jose.crypto.*;
 import com.nimbusds.jose.jwk.*;
 import com.nimbusds.jwt.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Service;
+import org.slf4j.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.stereotype.*;
 
-import java.text.ParseException;
+import java.text.*;
 
 @Component
 public class JwtCertValidator {

--- a/obs/obs-service-impl/src/main/java/com/adorsys/webank/obs/security/JwtHeaderExtractor.java
+++ b/obs/obs-service-impl/src/main/java/com/adorsys/webank/obs/security/JwtHeaderExtractor.java
@@ -1,0 +1,53 @@
+package com.adorsys.webank.obs.security;
+
+import com.nimbusds.jwt.*;
+import org.slf4j.*;
+
+import java.text.*;
+
+public class JwtHeaderExtractor {
+
+    private static final Logger logger = LoggerFactory.getLogger(JwtHeaderExtractor.class);
+
+    // Private constructor to prevent instantiation
+    private JwtHeaderExtractor() {
+
+    }
+
+    /**
+     * Extracts a specific field (e.g., accountJwt, kycCertJwt) from the JWT header.
+     *
+     * @param jwtToken The JWT token string.
+     * @param fieldName The name of the field to extract (e.g., "accountJwt", "kycCertJwt").
+     * @return The value of the requested field, or null if not present.
+     */
+    public static String extractField(String jwtToken, String fieldName) {
+
+        logger.info("JWT FROM HEADER: {}", jwtToken);
+        if (jwtToken == null || jwtToken.isEmpty()) {
+            logger.error("JWT token is null or empty.");
+            throw new IllegalArgumentException("JWT token is required.");
+        }
+        logger.debug("Attempting to extract field '{}' from JWT header.", fieldName);
+
+        try {
+            // Parse the JWT
+            SignedJWT signedJWT = SignedJWT.parse(jwtToken);
+            logger.debug("Successfully parsed JWT: {}", signedJWT);
+
+            // Extract the field from the header
+            Object fieldValue = signedJWT.getHeader().toJSONObject().get(fieldName);
+            if (fieldValue != null) {
+                String value = fieldValue.toString();
+                logger.info("Successfully extracted {} from JWT header: {}", fieldName, value);
+                return value;
+            }
+
+            logger.warn("Missing {} in JWT header.", fieldName);
+            return null;
+        } catch (ParseException e) {
+            logger.error("Failed to parse JWT token while extracting field '{}': {}", fieldName, e.getMessage(), e);
+            throw new IllegalArgumentException("Failed to parse JWT token.", e);
+        }
+    }
+}

--- a/obs/obs-service-impl/src/main/java/com/adorsys/webank/obs/serviceimpl/PayoutServiceImpl.java
+++ b/obs/obs-service-impl/src/main/java/com/adorsys/webank/obs/serviceimpl/PayoutServiceImpl.java
@@ -1,11 +1,11 @@
 package com.adorsys.webank.obs.serviceimpl;
 
-import com.adorsys.webank.obs.dto.MoneyTransferRequestDto;
-import com.adorsys.webank.obs.service.PayoutServiceApi;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import com.adorsys.webank.obs.dto.*;
+import com.adorsys.webank.obs.security.*;
+import com.adorsys.webank.obs.service.*;
+import org.slf4j.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.stereotype.*;
 
 @Service
 public class PayoutServiceImpl implements PayoutServiceApi {
@@ -19,12 +19,36 @@ public class PayoutServiceImpl implements PayoutServiceApi {
     }
 
     @Override
-    public String payout(MoneyTransferRequestDto moneyTransferRequestDto, String accountCertJwt) {
+    public String payout(MoneyTransferRequestDto moneyTransferRequestDto, String jwtToken) {
+        // Validate the JWT token
+        LOG.info("JWT TOKEN IS: {}", jwtToken);
+
+        // Extract accountCert and kycCert from the JWT header
+        String accountCert = JwtHeaderExtractor.extractField(jwtToken, "accountJwt");
+        LOG.info("Payout request: accountCert = {}", accountCert);
+
+        String kycCert = JwtHeaderExtractor.extractField(jwtToken, "kycCertJwt");
+        LOG.info("Payout request: kycCert = {}", kycCert);
+
+        // Validate the presence of accountCert
+        if (accountCert == null || accountCert.isEmpty()) {
+            throw new IllegalArgumentException("Account certificate is required for all transactions.");
+        }
+
+        // Parse the transaction amount
+        double amount = Double.parseDouble(moneyTransferRequestDto.getAmount());
+
+        // Validate based on the transaction amount
+        if (amount > 1000 && (kycCert == null || kycCert.isEmpty())) {
+            throw new IllegalArgumentException("KYC certificate is required for transactions exceeding 10,000 francs.");
+        }
+
+        // Proceed with the transaction
         return transactionHelper.validateAndProcessTransaction(
                 moneyTransferRequestDto.getSenderAccountId(),
                 moneyTransferRequestDto.getRecipientAccountId(),
                 moneyTransferRequestDto.getAmount(),
-                accountCertJwt,
+                jwtToken,
                 LOG
         );
     }

--- a/obs/obs-service-impl/src/test/java/com/adorsys/webank/obs/serviceimpl/PayoutServiceImplTest.java
+++ b/obs/obs-service-impl/src/test/java/com/adorsys/webank/obs/serviceimpl/PayoutServiceImplTest.java
@@ -1,81 +1,252 @@
-//package com.adorsys.webank.obs.serviceimpl;
-//
-//import com.adorsys.webank.obs.dto.MoneyTransferRequestDto;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.ArgumentMatchers;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.mockito.Mockito.*;
-//
-//@ExtendWith(MockitoExtension.class)
-//class PayoutServiceImplTest {
-//
-//    @Mock
-//    private TransactionHelper transactionHelper;
-//
-//    @InjectMocks
-//    private PayoutServiceImpl payoutService;
-//
-//    @Test
-//    void testPayoutSuccess() {
-//        MoneyTransferRequestDto request = new MoneyTransferRequestDto();
-//        request.setSenderAccountId("sender123");
-//        request.setRecipientAccountId("recipient456");
-//        request.setAmount("150.00");
-//
-//        String accountCertJwt = "valid-certificate-jwt";
-//        String expectedResponse = "transactionCertString Success";
-//
-//        when(transactionHelper.validateAndProcessTransaction(
-//                eq("sender123"),
-//                eq("recipient456"),
-//                eq("150.00"),
-//                eq(accountCertJwt),
-//                ArgumentMatchers.any())
-//        ).thenReturn(expectedResponse);
-//
-//        String response = payoutService.payout(request, accountCertJwt);
-//
-//        verify(transactionHelper, times(1)).validateAndProcessTransaction(
-//                eq("sender123"),
-//                eq("recipient456"),
-//                eq("150.00"),
-//                eq(accountCertJwt),
-//                ArgumentMatchers.any()
-//        );
-//        assertEquals(expectedResponse, response);
-//    }
-//
-//    @Test
-//    void testPayoutWhenHelperReturnsError() {
-//        MoneyTransferRequestDto request = new MoneyTransferRequestDto();
-//        request.setSenderAccountId("sender789");
-//        request.setRecipientAccountId("recipient012");
-//        request.setAmount("50.00");
-//
-//        String accountCertJwt = "invalid-certificate-jwt";
-//        String expectedError = "Invalid certificate or JWT. Payout Request failed";
-//
-//        when(transactionHelper.validateAndProcessTransaction(
-//                eq("sender789"),
-//                eq("recipient012"),
-//                eq("50.00"),
-//                eq(accountCertJwt),
-//                ArgumentMatchers.any())
-//        ).thenReturn(expectedError);
-//
-//        String response = payoutService.payout(request, accountCertJwt);
-//        verify(transactionHelper, times(1)).validateAndProcessTransaction(
-//                eq("sender789"),
-//                eq("recipient012"),
-//                eq("50.00"),
-//                eq(accountCertJwt),
-//                ArgumentMatchers.any()
-//        );
-//        assertEquals(expectedError, response);
-//    }
-//}
+package com.adorsys.webank.obs.serviceimpl;
+
+import com.adorsys.webank.obs.dto.MoneyTransferRequestDto;
+import com.adorsys.webank.obs.security.JwtHeaderExtractor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PayoutServiceImplTest {
+
+    @Mock
+    private TransactionHelper transactionHelper;
+
+    @InjectMocks
+    private PayoutServiceImpl payoutService;
+
+    private static final String VALID_JWT_TOKEN = "valid.jwt.token";
+    private static final String VALID_ACCOUNT_CERT = "valid.account.cert";
+    private static final String VALID_KYC_CERT = "valid.kyc.cert";
+    private static final String SENDER_ACCOUNT_ID = "sender123";
+    private static final String RECIPIENT_ACCOUNT_ID = "recipient456";
+    private static final String TRANSACTION_SUCCESS = "transaction.cert Success";
+
+    private MoneyTransferRequestDto smallAmountRequest;
+    private MoneyTransferRequestDto largeAmountRequest;
+
+    @BeforeEach
+    void setUp() {
+        // Setup small amount request (less than 1000)
+        smallAmountRequest = new MoneyTransferRequestDto();
+        smallAmountRequest.setSenderAccountId(SENDER_ACCOUNT_ID);
+        smallAmountRequest.setRecipientAccountId(RECIPIENT_ACCOUNT_ID);
+        smallAmountRequest.setAmount("500.00");
+
+        // Setup large amount request (greater than 1000)
+        largeAmountRequest = new MoneyTransferRequestDto();
+        largeAmountRequest.setSenderAccountId(SENDER_ACCOUNT_ID);
+        largeAmountRequest.setRecipientAccountId(RECIPIENT_ACCOUNT_ID);
+        largeAmountRequest.setAmount("1500.00");
+    }
+
+    @Test
+    void payout_withValidSmallAmountRequest_shouldSucceed() {
+        // Arrange
+        try (MockedStatic<JwtHeaderExtractor> extractorMock = mockStatic(JwtHeaderExtractor.class)) {
+            extractorMock.when(() -> JwtHeaderExtractor.extractField(eq(VALID_JWT_TOKEN), eq("accountJwt")))
+                    .thenReturn(VALID_ACCOUNT_CERT);
+            extractorMock.when(() -> JwtHeaderExtractor.extractField(eq(VALID_JWT_TOKEN), eq("kycCertJwt")))
+                    .thenReturn(null);
+
+            when(transactionHelper.validateAndProcessTransaction(
+                    eq(SENDER_ACCOUNT_ID),
+                    eq(RECIPIENT_ACCOUNT_ID),
+                    eq("500.00"),
+                    eq(VALID_JWT_TOKEN),
+                    any(Logger.class)
+            )).thenReturn(TRANSACTION_SUCCESS);
+
+            // Act
+            String result = payoutService.payout(smallAmountRequest, VALID_JWT_TOKEN);
+
+            // Assert
+            assertEquals(TRANSACTION_SUCCESS, result);
+            verify(transactionHelper).validateAndProcessTransaction(
+                    eq(SENDER_ACCOUNT_ID),
+                    eq(RECIPIENT_ACCOUNT_ID),
+                    eq("500.00"),
+                    eq(VALID_JWT_TOKEN),
+                    any(Logger.class)
+            );
+        }
+    }
+
+    @Test
+    void payout_withValidLargeAmountRequestAndKycCert_shouldSucceed() {
+        // Arrange
+        try (MockedStatic<JwtHeaderExtractor> extractorMock = mockStatic(JwtHeaderExtractor.class)) {
+            extractorMock.when(() -> JwtHeaderExtractor.extractField(eq(VALID_JWT_TOKEN), eq("accountJwt")))
+                    .thenReturn(VALID_ACCOUNT_CERT);
+            extractorMock.when(() -> JwtHeaderExtractor.extractField(eq(VALID_JWT_TOKEN), eq("kycCertJwt")))
+                    .thenReturn(VALID_KYC_CERT);
+
+            when(transactionHelper.validateAndProcessTransaction(
+                    eq(SENDER_ACCOUNT_ID),
+                    eq(RECIPIENT_ACCOUNT_ID),
+                    eq("1500.00"),
+                    eq(VALID_JWT_TOKEN),
+                    any(Logger.class)
+            )).thenReturn(TRANSACTION_SUCCESS);
+
+            // Act
+            String result = payoutService.payout(largeAmountRequest, VALID_JWT_TOKEN);
+
+            // Assert
+            assertEquals(TRANSACTION_SUCCESS, result);
+            verify(transactionHelper).validateAndProcessTransaction(
+                    eq(SENDER_ACCOUNT_ID),
+                    eq(RECIPIENT_ACCOUNT_ID),
+                    eq("1500.00"),
+                    eq(VALID_JWT_TOKEN),
+                    any(Logger.class)
+            );
+        }
+    }
+
+    @Test
+    void payout_withLargeAmountRequestWithoutKycCert_shouldThrowException() {
+        // Arrange
+        try (MockedStatic<JwtHeaderExtractor> extractorMock = mockStatic(JwtHeaderExtractor.class)) {
+            extractorMock.when(() -> JwtHeaderExtractor.extractField(eq(VALID_JWT_TOKEN), eq("accountJwt")))
+                    .thenReturn(VALID_ACCOUNT_CERT);
+            extractorMock.when(() -> JwtHeaderExtractor.extractField(eq(VALID_JWT_TOKEN), eq("kycCertJwt")))
+                    .thenReturn(null);
+
+            // Act & Assert
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+                payoutService.payout(largeAmountRequest, VALID_JWT_TOKEN);
+            });
+
+            assertEquals("KYC certificate is required for transactions exceeding 10,000 francs.", exception.getMessage());
+            verify(transactionHelper, never()).validateAndProcessTransaction(anyString(), anyString(), anyString(), anyString(), any(Logger.class));
+        }
+    }
+
+    @Test
+    void payout_withoutAccountCert_shouldThrowException() {
+        // Arrange
+        try (MockedStatic<JwtHeaderExtractor> extractorMock = mockStatic(JwtHeaderExtractor.class)) {
+            extractorMock.when(() -> JwtHeaderExtractor.extractField(eq(VALID_JWT_TOKEN), eq("accountJwt")))
+                    .thenReturn(null);
+
+            // Act & Assert
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+                payoutService.payout(smallAmountRequest, VALID_JWT_TOKEN);
+            });
+
+            assertEquals("Account certificate is required for all transactions.", exception.getMessage());
+            verify(transactionHelper, never()).validateAndProcessTransaction(anyString(), anyString(), anyString(), anyString(), any(Logger.class));
+        }
+    }
+
+    @Test
+    void payout_withEmptyAccountCert_shouldThrowException() {
+        // Arrange
+        try (MockedStatic<JwtHeaderExtractor> extractorMock = mockStatic(JwtHeaderExtractor.class)) {
+            extractorMock.when(() -> JwtHeaderExtractor.extractField(eq(VALID_JWT_TOKEN), eq("accountJwt")))
+                    .thenReturn("");
+
+            // Act & Assert
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+                payoutService.payout(smallAmountRequest, VALID_JWT_TOKEN);
+            });
+
+            assertEquals("Account certificate is required for all transactions.", exception.getMessage());
+            verify(transactionHelper, never()).validateAndProcessTransaction(anyString(), anyString(), anyString(), anyString(), any(Logger.class));
+        }
+    }
+
+    @Test
+    void payout_withNullJwtToken_shouldThrowException() {
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class, () -> {
+            payoutService.payout(smallAmountRequest, null);
+        });
+        verify(transactionHelper, never()).validateAndProcessTransaction(anyString(), anyString(), anyString(), anyString(), any(Logger.class));
+    }
+
+    @Test
+    void payout_withInvalidAmountFormat_shouldThrowException() {
+        // Arrange
+        MoneyTransferRequestDto invalidAmountRequest = new MoneyTransferRequestDto();
+        invalidAmountRequest.setSenderAccountId(SENDER_ACCOUNT_ID);
+        invalidAmountRequest.setRecipientAccountId(RECIPIENT_ACCOUNT_ID);
+        invalidAmountRequest.setAmount("not-a-number");
+
+        try (MockedStatic<JwtHeaderExtractor> extractorMock = mockStatic(JwtHeaderExtractor.class)) {
+            extractorMock.when(() -> JwtHeaderExtractor.extractField(eq(VALID_JWT_TOKEN), eq("accountJwt")))
+                    .thenReturn(VALID_ACCOUNT_CERT);
+
+            // Act & Assert
+            assertThrows(NumberFormatException.class, () -> {
+                payoutService.payout(invalidAmountRequest, VALID_JWT_TOKEN);
+            });
+            verify(transactionHelper, never()).validateAndProcessTransaction(anyString(), anyString(), anyString(), anyString(), any(Logger.class));
+        }
+    }
+
+    @Test
+    void payout_transactionHelperThrowsException_shouldPropagateException() {
+        // Arrange
+        try (MockedStatic<JwtHeaderExtractor> extractorMock = mockStatic(JwtHeaderExtractor.class)) {
+            extractorMock.when(() -> JwtHeaderExtractor.extractField(eq(VALID_JWT_TOKEN), eq("accountJwt")))
+                    .thenReturn(VALID_ACCOUNT_CERT);
+            extractorMock.when(() -> JwtHeaderExtractor.extractField(eq(VALID_JWT_TOKEN), eq("kycCertJwt")))
+                    .thenReturn(null);
+
+            when(transactionHelper.validateAndProcessTransaction(
+                    anyString(), anyString(), anyString(), anyString(), any(Logger.class)
+            )).thenThrow(new RuntimeException("Transaction processing error"));
+
+            // Act & Assert
+            RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+                payoutService.payout(smallAmountRequest, VALID_JWT_TOKEN);
+            });
+
+            assertEquals("Transaction processing error", exception.getMessage());
+        }
+    }
+
+    @Test
+    void payout_loggingFunctionality_shouldLogCorrectInformation() {
+        // Arrange
+        try (MockedStatic<JwtHeaderExtractor> extractorMock = mockStatic(JwtHeaderExtractor.class)) {
+            extractorMock.when(() -> JwtHeaderExtractor.extractField(eq(VALID_JWT_TOKEN), eq("accountJwt")))
+                    .thenReturn(VALID_ACCOUNT_CERT);
+            extractorMock.when(() -> JwtHeaderExtractor.extractField(eq(VALID_JWT_TOKEN), eq("kycCertJwt")))
+                    .thenReturn(VALID_KYC_CERT);
+
+            when(transactionHelper.validateAndProcessTransaction(
+                    anyString(), anyString(), anyString(), anyString(), any(Logger.class)
+            )).thenReturn(TRANSACTION_SUCCESS);
+
+            // Use ArgumentCaptor to verify logging parameters passed to TransactionHelper
+            ArgumentCaptor<Logger> loggerCaptor = ArgumentCaptor.forClass(Logger.class);
+
+            // Act
+            payoutService.payout(smallAmountRequest, VALID_JWT_TOKEN);
+
+            // Assert
+            verify(transactionHelper).validateAndProcessTransaction(
+                    anyString(), anyString(), anyString(), anyString(), loggerCaptor.capture()
+            );
+
+            Logger capturedLogger = loggerCaptor.getValue();
+            assertNotNull(capturedLogger);
+            assertEquals(PayoutServiceImpl.class.getName(), capturedLogger.getName());
+        }
+    }
+}

--- a/obs/obs-service-impl/src/test/java/com/adorsys/webank/obs/serviceimpl/PayoutServiceImplTest.java
+++ b/obs/obs-service-impl/src/test/java/com/adorsys/webank/obs/serviceimpl/PayoutServiceImplTest.java
@@ -1,81 +1,81 @@
-package com.adorsys.webank.obs.serviceimpl;
-
-import com.adorsys.webank.obs.dto.MoneyTransferRequestDto;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentMatchers;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.*;
-
-@ExtendWith(MockitoExtension.class)
-class PayoutServiceImplTest {
-
-    @Mock
-    private TransactionHelper transactionHelper;
-
-    @InjectMocks
-    private PayoutServiceImpl payoutService;
-
-    @Test
-    void testPayoutSuccess() {
-        MoneyTransferRequestDto request = new MoneyTransferRequestDto();
-        request.setSenderAccountId("sender123");
-        request.setRecipientAccountId("recipient456");
-        request.setAmount("150.00");
-
-        String accountCertJwt = "valid-certificate-jwt";
-        String expectedResponse = "transactionCertString Success";
-
-        when(transactionHelper.validateAndProcessTransaction(
-                eq("sender123"),
-                eq("recipient456"),
-                eq("150.00"),
-                eq(accountCertJwt),
-                ArgumentMatchers.any())
-        ).thenReturn(expectedResponse);
-
-        String response = payoutService.payout(request, accountCertJwt);
-
-        verify(transactionHelper, times(1)).validateAndProcessTransaction(
-                eq("sender123"),
-                eq("recipient456"),
-                eq("150.00"),
-                eq(accountCertJwt),
-                ArgumentMatchers.any()
-        );
-        assertEquals(expectedResponse, response);
-    }
-
-    @Test
-    void testPayoutWhenHelperReturnsError() {
-        MoneyTransferRequestDto request = new MoneyTransferRequestDto();
-        request.setSenderAccountId("sender789");
-        request.setRecipientAccountId("recipient012");
-        request.setAmount("50.00");
-
-        String accountCertJwt = "invalid-certificate-jwt";
-        String expectedError = "Invalid certificate or JWT. Payout Request failed";
-
-        when(transactionHelper.validateAndProcessTransaction(
-                eq("sender789"),
-                eq("recipient012"),
-                eq("50.00"),
-                eq(accountCertJwt),
-                ArgumentMatchers.any())
-        ).thenReturn(expectedError);
-
-        String response = payoutService.payout(request, accountCertJwt);
-        verify(transactionHelper, times(1)).validateAndProcessTransaction(
-                eq("sender789"),
-                eq("recipient012"),
-                eq("50.00"),
-                eq(accountCertJwt),
-                ArgumentMatchers.any()
-        );
-        assertEquals(expectedError, response);
-    }
-}
+//package com.adorsys.webank.obs.serviceimpl;
+//
+//import com.adorsys.webank.obs.dto.MoneyTransferRequestDto;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.ArgumentMatchers;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+//import static org.mockito.Mockito.*;
+//
+//@ExtendWith(MockitoExtension.class)
+//class PayoutServiceImplTest {
+//
+//    @Mock
+//    private TransactionHelper transactionHelper;
+//
+//    @InjectMocks
+//    private PayoutServiceImpl payoutService;
+//
+//    @Test
+//    void testPayoutSuccess() {
+//        MoneyTransferRequestDto request = new MoneyTransferRequestDto();
+//        request.setSenderAccountId("sender123");
+//        request.setRecipientAccountId("recipient456");
+//        request.setAmount("150.00");
+//
+//        String accountCertJwt = "valid-certificate-jwt";
+//        String expectedResponse = "transactionCertString Success";
+//
+//        when(transactionHelper.validateAndProcessTransaction(
+//                eq("sender123"),
+//                eq("recipient456"),
+//                eq("150.00"),
+//                eq(accountCertJwt),
+//                ArgumentMatchers.any())
+//        ).thenReturn(expectedResponse);
+//
+//        String response = payoutService.payout(request, accountCertJwt);
+//
+//        verify(transactionHelper, times(1)).validateAndProcessTransaction(
+//                eq("sender123"),
+//                eq("recipient456"),
+//                eq("150.00"),
+//                eq(accountCertJwt),
+//                ArgumentMatchers.any()
+//        );
+//        assertEquals(expectedResponse, response);
+//    }
+//
+//    @Test
+//    void testPayoutWhenHelperReturnsError() {
+//        MoneyTransferRequestDto request = new MoneyTransferRequestDto();
+//        request.setSenderAccountId("sender789");
+//        request.setRecipientAccountId("recipient012");
+//        request.setAmount("50.00");
+//
+//        String accountCertJwt = "invalid-certificate-jwt";
+//        String expectedError = "Invalid certificate or JWT. Payout Request failed";
+//
+//        when(transactionHelper.validateAndProcessTransaction(
+//                eq("sender789"),
+//                eq("recipient012"),
+//                eq("50.00"),
+//                eq(accountCertJwt),
+//                ArgumentMatchers.any())
+//        ).thenReturn(expectedError);
+//
+//        String response = payoutService.payout(request, accountCertJwt);
+//        verify(transactionHelper, times(1)).validateAndProcessTransaction(
+//                eq("sender789"),
+//                eq("recipient012"),
+//                eq("50.00"),
+//                eq(accountCertJwt),
+//                ArgumentMatchers.any()
+//        );
+//        assertEquals(expectedError, response);
+//    }
+//}


### PR DESCRIPTION
…ficate extraction and transaction validation

# Ticket Description
## Title: Enhance Transaction Validation with Modular Certificate Extraction
### Description:
The goal of this ticket was to ensure **secure and reliable validation** of transactions based on the transaction amount.

For transactions exceeding a certain threshold (e.g., **> 10,000 francs**), **KYC certification** (`kycCert`) is required, while **all transactions** mandate an **account certificate** (`accountCert`).

Previously, ambiguity in certificate extraction caused issues in `JwtCertValidator`, leading to incorrect or overlapping results. To address this:

- ✅ **Created** a new `JwtHeaderExtractor` class to handle **explicit extraction** of certificates (`accountCert` and `kycCert`) from the JWT header.  
- ✅ **Updated** `PayoutServiceImpl` to enforce **proper validation** of certificates based on the transaction amount.  
- ✅ **Ensured modularity** by separating certificate extraction logic from validation logic, improving **reusability** and **maintainability**.
